### PR TITLE
Repository template reorder

### DIFF
--- a/public/views/repositories/_repository.html.erb
+++ b/public/views/repositories/_repository.html.erb
@@ -1,29 +1,36 @@
-<% if !full %>
-<div class="recordrow">
-  <% end %>
-  <%= (full ? '<h1>' : '<h3>').html_safe %>
-    <% if !full %><a class="record-title" href="<%= app_prefix(result['uri']) %>"><% end %><%= result['name']%>
-      <% if !full %></a><% end %>
+<%# Notes:
+ - full: in the context of the repository show template and the record
+   repository accordion
+ - !full: in the context of a repository search result
+ - result: the repository hash
+%>
+<% if !full %><div class="recordrow"><% end %>
+
+<%# Yale override to only show title and badge on search results %>
+<% unless full %>
+  <h3>
+    <a class="record-title" href="<%= app_prefix(result['uri']) %>">
+      <%= result['name']%>
       <% if result.has_key?('image_url') %>
-      <%= link_to image_tag(result['image_url'], :alt => "#{t('repository._singular')}: #{result['name']}"), result['uri'], {:class => 'repository-logo'} %>
+        <%= link_to image_tag(result['image_url'], :alt => "#{t('repository._singular')}: #{result['name']}"), result['uri'], {:class => 'repository-logo'} %>
       <% end %>
-      <%= (full ? '</h1>' : '</h3>').html_safe %>
-
-      <div class="badge-and-identifier">
-        <div class="record-type-badge repository">
-          <i class="fa fa-home"></i>&#160;<%= t('repository._singular') %>
-        </div>
-
-        <div class="<%= (full ? 'clear' : 'recordsummary') %>">
-          <%# we've removed the Parent Institution information from here,
-          since all of the repos are part of Yale %>
-          <% if full %>
-          <%= render partial: 'repositories/full_repo', locals: {:info => result['repo_info'], :url => result['url']} %>
-          <% else %>
-          <div><strong>Number of <%= t('resource._plural') %>:</strong> <%= result['count'] %></div>
-          <% end %>
-        </div>
-      </div>
-      <% if !full %>
+    </a>
+  </h3>
+  <div class="badge-and-identifier">
+    <div class="record-type-badge repository">
+      <i class="fa fa-home"></i>&#160;<%= t('repository._singular') %>
     </div>
-    <% end %>
+  </div>
+<% end %>
+
+<div class="<%= (full ? 'clear' : 'recordsummary') %>">
+  <%# we've removed the Parent Institution information from here,
+          since all of the repos are part of Yale %>
+  <% if full %>
+    <%= render partial: 'repositories/full_repo', locals: {:info => result['repo_info'], :url => result['url']} %>
+  <% else %>
+    <div><strong>Number of <%= t('resource._plural') %>:</strong> <%= result['count'] %></div>
+  <% end %>
+</div>
+
+<% if !full %></div><% end %>

--- a/public/views/repositories/_repository_details.html.erb
+++ b/public/views/repositories/_repository_details.html.erb
@@ -1,0 +1,3 @@
+<%# Yale override to drop the <h2> header as is a duplicate of the accordion header %>
+<p> <%= "#{t('repository.part')} #{@repo_info['top']['name']} #{t('repository._singular')}" %></p>
+<%= render partial: 'repositories/full_repo', locals: {:info => @repo_info, :url => @repo_info['top']['url']} %>

--- a/public/views/repositories/show.html.erb
+++ b/public/views/repositories/show.html.erb
@@ -1,13 +1,19 @@
 <div id="main-content" class="repositories">
-
-  <div class="abstract">
-    <%= render partial: 'repositories/repository', locals: {:result => @result,  :full => true} %>
+  <h1>
+    <%= @result['name']%>
+    <% if @result.has_key?('image_url') %>
+      <%= link_to image_tag(@result['image_url'], :alt => "#{t('repository._singular')}: #{@result['name']}"), @result['uri'], {:class => 'repository-logo'} %>
+    <% end %>
+  </h1>
+  <div class="badge-and-identifier">
+    <div class="record-type-badge repository">
+      <i class="fa fa-home"></i>&#160;<%= t('repository._singular') %>
+    </div>
   </div>
-
-<hr/>
 
   <%= render partial: 'shared/search', locals: {
    :search_url => "#{@result['uri']}/search",
+   :header_size => 2,
    :title => t('repository._singular'),
    :limit_options =>  [["#{t('actions.search')} #{t('search-limits.all')}",''],
             [t('search-limit', :limit => t('search-limits.resources')),'resource']],
@@ -29,6 +35,10 @@
 	<% end %>
       </ul>
     </div>
+  </div>
 
+  <div class="abstract">
+    <h2><%= t('repository.details') %></h2>
+    <%= render partial: 'repositories/repository', locals: {:result => @result,  :full => true} %>
   </div>
 </div>


### PR DESCRIPTION
In support of the changes discussed in https://www.pivotaltracker.com/story/show/172937259.

This PR rearranges the repository search form and "what's in" icon box above the repository metadata sections (keeping the search above the fold).

To accomodate this, we had to slightly rework the existing template overrides to ensure the title and badge were output above the search box -- originally these were output in the metadata template.