### PR TITLE
Exclude accession general_note and payment_summary from the PUI keyword searches

### DIFF
--- a/indexer/plugin_init.rb
+++ b/indexer/plugin_init.rb
@@ -1,0 +1,4 @@
+if IndexerCommonConfig.respond_to?(:exclude_from_public_keyword_search)
+  IndexerCommonConfig.exclude_from_public_keyword_search('accession', 'general_note')
+  IndexerCommonConfig.exclude_from_public_keyword_search('accession', 'payment_summary')
+end


### PR DESCRIPTION
We've introduced a new API to allow plugins to filter fields from both the staff and PUI keyword search: see new commit in the `yale_rebased` branch of ArchivesSpace: https://github.com/hudmol/archivesspace/commit/8cbd5ab3999ebc07ffe06ce1e9843d7df8607859

The change here uses that new API to register the accession fields `general_note` and `payment_summary` to be excluded from the public keyword search.
