### PR TITLE
Merge 3.3.1 work into trunk

### DIFF
--- a/indexer/plugin_init.rb
+++ b/indexer/plugin_init.rb
@@ -1,4 +1,10 @@
 if IndexerCommonConfig.respond_to?(:exclude_from_public_keyword_search)
   IndexerCommonConfig.exclude_from_public_keyword_search('accession', 'general_note')
   IndexerCommonConfig.exclude_from_public_keyword_search('accession', 'payment_summary')
+  IndexerCommonConfig.exclude_from_public_keyword_search('repository', 'location')
+  IndexerCommonConfig.exclude_from_public_keyword_search('resource', 'ead_location')
+  IndexerCommonConfig.exclude_from_public_keyword_search('resource', 'finding_aid_status')
+  IndexerCommonConfig.exclude_from_public_keyword_search('resource', 'finding_aid_description_rules')
+  IndexerCommonConfig.exclude_from_public_keyword_search('resource', 'level')
+  IndexerCommonConfig.exclude_from_public_keyword_search('archival_object', 'level')
 end

--- a/public/assets/yale.css
+++ b/public/assets/yale.css
@@ -1089,8 +1089,12 @@ span.subrepo-branch {
 }
 
 /*mdc: ask about updating this in the sass files in our fork, instead */
-/* this is due to the fact that the search results on top conatainer, subject, agent, etc., pages are not in a search-results div*/
-.recordrow {
+/* what's below is a repeat of delcarations from thumbnails.scss, which is needed somewhere due to the fact that the search results on top conatainer, subject, agent, etc., pages are not in a search-results div*/
+/* and... the col-sm-12 bit is to ensure that the repository record rows will NOT get flexed in the same way, since those are in a bootstrap column of size 9 (or we could put the repo thumnbail in the pui thumbnail area, but since we don't use those right now)...
+so yeah, that last part is brittle, but it does not rely on any CSS selectors that are not available in every browser...
+but really, aspace should have classed divs for each type, or at least a consistent class.  right now, there are .containers, .search-results, and
+a whole lotta nothing on the other browse pages, e.g. for repositories, subjects, agents, etc. */
+.col-sm-12 .recordrow {
   display: flex;
 }
 .recordrow .pui-thumbnail {

--- a/public/assets/yale.css
+++ b/public/assets/yale.css
@@ -1088,13 +1088,10 @@ span.subrepo-branch {
   margin-left: 26px;
 }
 
-/*mdc: ask about updating this in the sass files in our fork, instead */
-/* what's below is a repeat of delcarations from thumbnails.scss, which is needed somewhere due to the fact that the search results on top conatainer, subject, agent, etc., pages are not in a search-results div*/
-/* and... the col-sm-12 bit is to ensure that the repository record rows will NOT get flexed in the same way, since those are in a bootstrap column of size 9 (or we could put the repo thumnbail in the pui thumbnail area, but since we don't use those right now)...
-so yeah, that last part is brittle, but it does not rely on any CSS selectors that are not available in every browser...
-but really, aspace should have classed divs for each type, or at least a consistent class.  right now, there are .containers, .search-results, and
-a whole lotta nothing on the other browse pages, e.g. for repositories, subjects, agents, etc. */
-.col-sm-12 .recordrow {
+/*mdc: review and fix later.  see thumbnails.scss */
+/* and current issues in PROD, e.g. https://archives.yale.edu/repositories/11/resources/1529/digital_materials 
+vs. https://archives.yale.edu/repositories/11/top_containers/350870 */
+.concept-records .recordrow, .containers .recordrow {
   display: flex;
 }
 .recordrow .pui-thumbnail {

--- a/public/assets/yale.css
+++ b/public/assets/yale.css
@@ -512,8 +512,8 @@ not just a regular definiton list, with a bit of padding for the dd elements */
   font-family: "Mallory-Medium";
 }
 
-/*mdc: new patch to remove newly-added icons from the pennant-style stylin' of our breadcrumbs */
-ul.breadcrumb > li span {
+/* krkptrk: 3.3.1 refinement of previous patch to address icons more narrowly */
+ul.breadcrumb > li span.record-type-badge {
   display: none;
 }
 

--- a/public/assets/yale.css
+++ b/public/assets/yale.css
@@ -1087,3 +1087,37 @@ span.subrepo-branch {
   border-bottom: 2px solid #ddd;
   margin-left: 26px;
 }
+
+/*mdc: ask about updating this in the sass files in our fork, instead */
+/* this is due to the fact that the search results on top conatainer, subject, agent, etc., pages are not in a search-results div*/
+.recordrow {
+  display: flex;
+}
+.recordrow .pui-thumbnail {
+  flex-shrink: 0;
+  flex-grow: 0;
+  flex:0 0 84px
+}
+.recordrow .pui-thumbnail-spacer {
+  flex-shrink: 0;
+  flex-grow: 0;
+  flex:0 0 84px
+}
+.recordrow .pui-thumbnail {
+  float: none;
+  border: none;
+  min-width: initial;
+  margin:0
+}
+.recordrow .pui-thumbnail img {
+  object-fit: cover;
+  object-position: center;
+  height: 80px;
+  width:80px
+}
+.recordrow .pui-thumbnail .pui-thumbnail-caption {
+  display:none
+}
+.recordrow .pui-thumbnail .pui-thumbnail-help-text {
+  display:none
+}

--- a/public/assets/yale.css
+++ b/public/assets/yale.css
@@ -512,8 +512,8 @@ not just a regular definiton list, with a bit of padding for the dd elements */
   font-family: "Mallory-Medium";
 }
 
-/*mdc: new patch to remove newly-added icons from displaying in our locally styled breadcrumbs, aside from the last list item, which doensn't have as much pennant-style stylin' */
-ul.breadcrumb > li:not(:last-child) span {
+/*mdc: new patch to remove newly-added icons from the pennant-style stylin' of our breadcrumbs */
+ul.breadcrumb > li span {
   display: none;
 }
 

--- a/public/assets/yale.css
+++ b/public/assets/yale.css
@@ -512,6 +512,11 @@ not just a regular definiton list, with a bit of padding for the dd elements */
   font-family: "Mallory-Medium";
 }
 
+/*mdc: new patch to remove newly-added icons from displaying in our locally styled breadcrumbs, aside from the last list item, which doensn't have as much pennant-style stylin' */
+ul.breadcrumb > li:not(:last-child) span {
+  display: none;
+}
+
 /*mdc: i just can't stand those rounded pills no more */
 /* line 109 aspace.scss */
 .tabbing.nav-pills > li:first-child a {

--- a/public/views/agents/show.html.erb
+++ b/public/views/agents/show.html.erb
@@ -32,7 +32,9 @@
     <%# Yale override: we are only adding this local override for the Suggest a Correction feature.  Too bad there's not a shared file that could be a placeholder, but that could be a good feature request. %>
     <%= render partial: 'shared/report_problem' %>
     <%# FOUND IN SECTION %>
-    <%= render partial: 'shared/results', locals: {:results => @results, :pager => @pager} %>
+    <div class="concept-records">
+      <%= render partial: 'shared/results', locals: {:results => @results, :pager => @pager} %>
+    </div>
   </div>
 
   <% if show_agents_sidebar?(@result) %>

--- a/public/views/agents/show.html.erb
+++ b/public/views/agents/show.html.erb
@@ -1,3 +1,5 @@
+<% json = @result.json %>
+
 <div id="main-content" class="agents">
 
   <div class="row" id="info_row">
@@ -9,55 +11,68 @@
     </div>
   </div>
 
+
 <div class="row">
   <div class="col-sm-9">
-    <% if !@result.dates.blank? %>
-      <h2><%= t('agent._public.section.dates_of_existence') %></h2>
-      <%= render partial: 'shared/dates', locals: {:dates => @result.dates} %>
-    <% end %>
-    <%= render partial: 'shared/display_notes' %>
+    <%= render partial: 'dates', locals: {:result => @result} %>
+    <%= render partial: 'parallel_names', locals: {:result => @result} %>
+    <%= render partial: 'shared/notes', locals: {:result => @result, note_label: I18n.t('agent_notes.note_bioghist'), note_type: 'note_bioghist'} %>
+    <%= render partial: 'shared/notes', locals: {:result => @result, note_label: I18n.t('agent_notes.note_general_context'), note_type: 'note_general_context'} %>
+    <%= render partial: 'shared/notes', locals: {:result => @result, note_label: I18n.t('agent_notes.note_legal_status'), note_type: 'note_legal_status'} %>
+    <%= render partial: 'shared/notes', locals: {:result => @result, note_label: I18n.t('agent_notes.note_mandate'), note_type: 'note_mandate'} %>
+    <%= render partial: 'shared/notes', locals: {:result => @result, note_label: I18n.t('agent_notes.note_structure_or_genealogy'), note_type: 'note_structure_or_genealogy'} %>
+    <%= render partial: 'gender', locals: {:result => @result} %>
+    <%= render partial: 'subjects', locals: {:result => @result, subject_label: I18n.t('agent_function._plural'), subject_type: 'agent_functions'} %>
+    <%= render partial: 'subjects', locals: {:result => @result, subject_label: I18n.t('agent_occupation._plural'), subject_type: 'agent_occupations'} %>
+    <%= render partial: 'subjects', locals: {:result => @result, subject_label: I18n.t('agent_place._plural'), subject_type: 'agent_places'} %>
+    <%= render partial: 'subjects', locals: {:result => @result, subject_label: I18n.t('agent_topic._plural'), subject_type: 'agent_topics'} %>
+    <%= render partial: 'shared/languages', locals: {:result => @result} %>
+    <%= render partial: 'shared/metadata_rights_declarations', locals: {:result => @result} %>
+    <%= render partial: 'snac', locals: {:result => @result} %>
+    <%# Yale override: we are only adding this local override for the Suggest a Correction feature.  Too bad there's not a shared file that could be a placeholder, but that could be a good feature request. %>
     <%= render partial: 'shared/report_problem' %>
- <% if !@results.blank? && @results['total_hits'] > 0 %>
-     <h2><%= t('found', {:count => @results['total_hits'], :type => @results['total_hits'] == 1? t('coll_obj._singular') : t('coll_obj._plural')}) %>:</h2>
-         <%= render partial: 'shared/pagination', locals: {:pager  => @pager}  %>
-         <% @results.records.each do |result| %>
-           <%= render partial: 'shared/result', locals: {:result => result, :props => {:full => false}} %>
-         <% end %>
-         <%= render partial: 'shared/pagination', locals: {:pager  => @pager}  %>
-   <% end %>
+    <%# FOUND IN SECTION %>
+    <%= render partial: 'shared/results', locals: {:results => @results, :pager => @pager} %>
   </div>
-  <div id="sidebar" class="col-sm-3 sidebar sidebar-container">
-    <% if @result.json['names'].length > 1 ||
-          (@result.respond_to?(:related_agents) && !ASUtils.wrap(@result.related_agents).empty?) ||
-          ASUtils.wrap(@result.external_documents).length > 0 %>
-    <%# added the gsub part to deal with name/title agents.  remove if we ever find a proper fix for those headings. %>
-    <h3><%= t('more_about') %> '<%= @result.display_string.gsub(/\$\w:\s/, '') %>'</h3>
-    <div class="acc_holder clear" >
-      <div class="panel-group" id="agent_accordion">
-        <% if @result.json['names'].length > 1 %>
-          <% other_names = @result.json['names'].reject{|name| name['is_display_name']}.collect{|name| name['sort_name']} %>
-          <% x = "<p>#{t('agent._public.section.other_names_preamble')}</p>" %>
-          <% x += render partial: 'shared/present_list', locals: {:list =>  other_names, :list_clss => 'other_names'} %>
-          <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('agent._public.section.other_names'), :p_id => 'other_names_list', :p_body => x.html_safe} %>
-        <% end %>
-        <% if @result.respond_to?(:related_agents) && !ASUtils.wrap(@result.related_agents).empty? %>
-          <% x = render partial: 'agents/related_agents', locals: {:related_agents => @result.related_agents, :list_clss => 'related_agents'} %>
-          <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('agent._public.section.related_agents'), :p_id => 'related_agents_list', :p_body => x} %>
-        <% end %>
-        <% unless @result.external_documents.blank? %>
-          <% x = render partial: 'shared/present_list_external_docs', locals: {:list =>  @result.external_documents, :list_clss => 'external_docs'} %>
-          <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('external_docs'), :p_id => 'ext_doc_list', :p_body => x} %>
-        <% end %>
-      </div>
-    </div>
-    <script type="text/javascript" >
-        initialize_accordion("#agent_accordion .note_panel", "<%= t('accordion.expand') %>" , "<%= t('accordion.collapse') %>");
-    </script>
 
+  <% if show_agents_sidebar?(@result) %>
+    <div id="sidebar" class="col-sm-3 sidebar sidebar-container">
+      <%# added the gsub part to deal with name/title agents.  remove if we ever find a proper fix for those headings. %>
+      <h3><%= t('more_about') %> '<%= @result.display_string.gsub(/\$\w:\s/, '') %>'</h3>
+      <div class="acc_holder clear" >
+        <div class="panel-group" id="agent_accordion">
+
+          <% n = render partial: 'name', locals: {:result => @result} %>
+          <%= render partial: 'shared/accordion_panel', locals:
+            {:p_title =>  I18n.t('agent._public.section.other_names'),
+              :p_id => "names_panel",
+              :p_body => n } %>
+
+          <% if @result.respond_to?(:related_agents) && !ASUtils.wrap(@result.related_agents).empty? %>
+            <% x = render partial: 'agents/related_agents', locals: {:related_agents => @result.json['related_agents'], :list_clss => 'related_agents'} %>
+            <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('agent._public.section.related_agents'), :p_id => 'related_agents_list', :p_body => x} %>
+          <% end %>
+
+          <% unless json['agent_resources'].blank? %>
+            <% x = render partial: 'shared/present_list_agent_resources', locals: {:list =>  json['agent_resources'], :list_clss => 'external_docs'} %>
+            <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('agent_resource._plural'), :p_id => 'agent_resource_list', :p_body => x} %>
+          <% end %>
+
+
+          <% unless @result.external_documents.blank? %>
+            <% x = render partial: 'shared/present_list_external_docs', locals: {:list =>  @result.external_documents, :list_clss => 'external_docs'} %>
+            <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('external_docs'), :p_id => 'ext_doc_list', :p_body => x} %>
+          <% end %>
+
+        </div>
+      </div>
+      <script type="text/javascript" >
+          initialize_accordion("#agent_accordion .note_panel", "<%= t('accordion.expand') %>" , "<%= t('accordion.collapse') %>", <%= AppConfig[:pui_expand_all] %>);
+      </script>
   <% end %>
+
   <% if !@facets.blank? || !@filters.blank? %>
-  <%= render partial: 'shared/facets' %>
+    <%= render partial: 'shared/facets' %>
   <% end %>
   </div>
-</div>
 </div>

--- a/public/views/layout_head.html.erb
+++ b/public/views/layout_head.html.erb
@@ -15,7 +15,7 @@
 <!--  expand all, but only if the screen width is gte 768px  -->
 <script type="text/javascript" >
   $( function() {
-    if ($(window).width() >= 768) { collapse_all('.note_panel',true); }
+    if ($(window).width() >= 768) { expandAllByDefault('.note_panel', false); }
   } );
 </script>
 <% end %>

--- a/public/views/repositories/_repository.html.erb
+++ b/public/views/repositories/_repository.html.erb
@@ -10,10 +10,10 @@
   <h3>
     <a class="record-title" href="<%= app_prefix(result['uri']) %>">
       <%= result['name']%>
-      <% if result.has_key?('image_url') %>
-        <%= link_to image_tag(result['image_url'], :alt => "#{t('repository._singular')}: #{result['name']}"), result['uri'], {:class => 'repository-logo'} %>
-      <% end %>
     </a>
+    <% if result.has_key?('image_url') %>
+      <%= link_to image_tag(result['image_url'], :alt => "#{t('repository._singular')}: #{result['name']}"), result['uri'], {:class => 'repository-logo'} %>
+    <% end %>
   </h3>
   <div class="badge-and-identifier">
     <div class="record-type-badge repository">

--- a/public/views/shared/_result.html.erb
+++ b/public/views/shared/_result.html.erb
@@ -152,7 +152,7 @@ end
      <div class="result_context">
 
       <%# new stuff, but also need to fix the repo name that's used on repository search results, which includes the short name needlessly %>
-       <% if result.primary_type == 'repository' %>
+       <% if result.primary_type == 'repository' && result.resolved_repository.try(:fetch, 'parent_institution_name', nil) %>
        <div><strong><%= t('parent_inst') %>:</strong>
          <%= result.resolved_repository.fetch('parent_institution_name') %>
        </div>

--- a/public/views/subjects/show.html.erb
+++ b/public/views/subjects/show.html.erb
@@ -1,69 +1,45 @@
-<%# we are only adding this local override for the "Suggest a Correction" feature.  Too bad there's not a shared file that could be a placeholder, but that could be a good feature request. %>
 <div id="main-content">
-
-    <div class="row" id="info_row">
-        <div class="information col-sm-7">
-            <%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %>
-        </div>
-        <div class="page_actions col-sm-5 right">
-            <%= render partial: 'shared/page_actions', locals: {:record => @result, :title => @result.display_string, :url => request.fullpath } %>
-        </div>
+  <div class="row" id="info_row">
+    <div class="information col-sm-7">
+      <%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %>
     </div>
-
-    <div class="row">
-        <div class="information col-sm-9">
-            <div class="clear">
-                <span class="inline-label clear"><%= t('enumeration_names.subject_source') %>: </span><%= t("enumerations.subject_source.#{@result['json']['source']}" ) %>
-            </div>
-
-            <% if !@result.dates.blank? %>
-            <% render partial: 'shared/dates', locals: {:dates => @result.dates} %>
-            <% end %>
-
-            <% if !@result['json']['component_id'].blank? %>
-            <span class='component'><%= t(component._singular) %>: <%= @result['json']['component_id'] %></span>
-            <% end %>
-            <% if !@result['json']['ref_id'].blank? %>
-            <span class='ref_id'>[Ref. ID: <%= @result['json']['ref_id'] %>]</span>
-            <% end %>
-            <% if @result['json']['scope_note'].present? %>
-            <span class="inline-label"><%= t('scope_note') %>:</span> <%= process_mixed_content( @result['json']['scope_note']).html_safe %>
-            <% end %>
-
-            <%= render partial: 'shared/display_notes' %>
-            <%= render partial: 'shared/report_problem' %>
-
-            <% unless @results.blank? || @results['total_hits'] == 0 %>
-            <h2><%= t('found', {:count => @results['total_hits'], :type => @results['total_hits'] == 1? t('coll_obj._singular') : t('coll_obj._plural')}) %>:</h2>
-            <% @results.records.each do |result| %>
-            <%= render partial: 'shared/result', locals: {:result => result, :props => {:full => false}} %>
-            <% end %>
-            <%= render partial: 'shared/pagination', locals: {:pager  => @pager}  %>
-
-            <% end %>
-        </div>
-        <div id="sidebar" class="col-sm-3 sidebar sidebar-container">
-            <h3><%= t('more_about') %> '<%= @result.display_string %>'</h3>
-
-            <div class="acc_holder clear" >
-                <div class="panel-group" id="res_accordion">
-                    <% if !(terms = ASUtils.wrap(@result['json']['terms'])).empty? %>
-                    <% x = render partial: 'subjects/terms', locals: {:terms =>  terms, :list_clss => 'terms'} %>
-                    <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('subject_term_type'), :p_id => 'subject_terms', :p_body => x} %>
-                    <% end %>
-                    <% unless @result.external_documents.blank? %>
-                    <% x = render partial: 'shared/present_list_external_docs', locals: {:list =>  @result.external_documents, :list_clss => 'external_docs'} %>
-                    <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('external_docs'), :p_id => 'ext_doc_list', :p_body => x} %>
-                    <% end %>
-                </div>
-            </div>
-            <script type="text/javascript" >
-                initialize_accordion(".note_panel", "<%= t('accordion.expand') %>" , "<%= t('accordion.collapse') %>");
-            </script>
-
-            <% unless @results.blank? || @results['total_hits'] == 0 %>
-            <%= render partial: 'shared/facets' %>
-            <% end %>
-        </div>
+    <div class="page_actions col-sm-5 right">
+      <%= render partial: 'shared/page_actions', locals: {:record => @result, :title => @result.display_string, :url => request.fullpath } %>
     </div>
+  </div>
+  <div class="row">
+    <div class="information col-sm-9">
+      <div class="clear">
+        <span class="inline-label clear"><%= t('enumeration_names.subject_source') %>: </span><%= t("enumerations.subject_source.#{@result['json']['source']}" ) %>
+      </div>
+      <% if @result['json']['scope_note'].present? %>
+        <span class="inline-label"><%= t('scope_note') %>:</span> <%= process_mixed_content( @result['json']['scope_note']).html_safe %>
+      <% end %>
+      <%# Yale override: we are only adding this local override for the Suggest a Correction feature.  Too bad there's not a shared file that could be a placeholder, but that could be a good feature request. %>
+      <%= render partial: 'shared/report_problem' %>
+      <%# FOUND IN SECTION %>
+      <%= render partial: 'shared/results', locals: {:results => @results, :pager => @pager} %>
+    </div>
+    <div id="sidebar" class="col-sm-3 sidebar sidebar-container">
+      <h3><%= t('more_about') %> '<%= @result.display_string %>'</h3>
+      <div class="acc_holder clear" >
+        <div class="panel-group" id="res_accordion">
+          <% if !(terms = ASUtils.wrap(@result['json']['terms'])).empty? %>
+            <% x = render partial: 'subjects/terms', locals: {:terms =>  terms, :list_clss => 'terms'} %>
+            <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('subject_term_type'), :p_id => 'subject_terms', :p_body => x} %>
+          <% end %>
+          <% unless @result.external_documents.blank? %>
+            <% x = render partial: 'shared/present_list_external_docs', locals: {:list =>  @result.external_documents, :list_clss => 'external_docs'} %>
+            <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('external_docs'), :p_id => 'ext_doc_list', :p_body => x} %>
+          <% end %>
+        </div>
+      </div>
+      <script type="text/javascript" >
+        initialize_accordion(".note_panel", "<%= t('accordion.expand') %>" , "<%= t('accordion.collapse') %>", <%= AppConfig[:pui_expand_all] %>);
+      </script>
+      <% unless @results.blank? || @results['total_hits'] == 0 %>
+        <%= render partial: 'shared/facets' %>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/public/views/subjects/show.html.erb
+++ b/public/views/subjects/show.html.erb
@@ -18,7 +18,9 @@
       <%# Yale override: we are only adding this local override for the Suggest a Correction feature.  Too bad there's not a shared file that could be a placeholder, but that could be a good feature request. %>
       <%= render partial: 'shared/report_problem' %>
       <%# FOUND IN SECTION %>
-      <%= render partial: 'shared/results', locals: {:results => @results, :pager => @pager} %>
+      <div class="concept-records">
+        <%= render partial: 'shared/results', locals: {:results => @results, :pager => @pager} %>
+      </div>
     </div>
     <div id="sidebar" class="col-sm-3 sidebar sidebar-container">
       <h3><%= t('more_about') %> '<%= @result.display_string %>'</h3>


### PR DESCRIPTION
This PR will merge work done for the 3.3.1 core upgrade into the trunk. Specific 
commits are as follows:

- collapse_all refactored to expandAllByDefault
- even though we will always have a parent institution, we should not require that
- fix an HTML invalidity issue that is in core... and remember to make a pull request to core
- merge updates, but keep our report a problem feature
- update for local breadcrumb display
- even less icons, given the fact that sometimes there is only one breadcrumb, and also because the record type is not always set as the correct one right now, and since the fall back is just a square, and yeah...
- temp updates in plugin before we update our branch, right
- quick patch to keep the repository browse lists rigid, rather than flexed
- a central refactor is still in order, but for now...
- update excluded fields
- refined hide [CSS] rule for icons
